### PR TITLE
fix(hero): adjust layout for responsive design

### DIFF
--- a/app/(marketing)/_components/hero.tsx
+++ b/app/(marketing)/_components/hero.tsx
@@ -35,7 +35,7 @@ export const Hero = () => {
 
       <div className="mx-auto mt-6 flex w-full max-w-2xl flex-col items-center justify-center space-y-4 sm:flex-row sm:space-x-4 sm:space-y-0">
         <BlurFade delay={0.75} inView>
-          <div className="flex gap-4">
+          <div className="flex w-full flex-col gap-4 sm:flex-row sm:w-auto">
             <Link
               className={cn(buttonVariants({ size: "lg" }))}
               href={"/login"}


### PR DESCRIPTION
## Correção de layout no mobile

O layout no mobile estava quebrando por causa dos botões de **CTA**, que ficavam lado a lado de forma incorreta.

**Antes:**

```jsx
<div className="flex gap-4">
```
<img width="746" height="686" alt="image" src="https://github.com/user-attachments/assets/98551717-85e0-45d7-af0b-194718a4dd3d" />

**Agora:**

```jsx
<div className="flex w-full flex-col gap-4 sm:flex-row sm:w-auto">
```
<img width="748" height="544" alt="image" src="https://github.com/user-attachments/assets/089d035f-51aa-4f6e-879b-edf9c27fa47f" />

Com essa alteração, os botões passam a ficar empilhados no mobile e lado a lado apenas em telas maiores, deixando o layout responsivo.